### PR TITLE
Update package versions

### DIFF
--- a/resources/clj/new/re_frame_template/deps.edn
+++ b/resources/clj/new/re_frame_template/deps.edn
@@ -1,18 +1,18 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         org.clojure/core.async {:mvn/version "1.1.587"}
         org.clojure/clojurescript
         {:exclusions [com.google.javascript/closure-compiler-unshaded
                       org.clojure/google-closure-library
                       org.clojure/google-closure-library-third-party]
-         :mvn/version "1.10.742"}
+         :mvn/version "1.11.60"}
         seancorfield/clj-new {:mvn/version "1.0.199"}
         reagent {:mvn/version "0.9.1"}
         re-frame {:mvn/version "0.12.0"}{{#re-com?}}
         re-com {:mvn/version "2.8.0"}{{/re-com?}}{{#re-pressed?}}
         re-pressed {:mvn/version "0.3.1"}{{/re-pressed?}}{{#breaking-point?}}
         breaking-point {:mvn/version "0.1.2"}{{/breaking-point?}}
-        thheller/shadow-cljs {:mvn/version "2.8.109"}}
+        thheller/shadow-cljs {:mvn/version "2.20.14"}}
  :aliases
  {
   :dev {:extra-deps {binaryage/devtools {:mvn/version "1.0.0"}{{#10x?}}

--- a/resources/clj/new/re_frame_template/deps.edn
+++ b/resources/clj/new/re_frame_template/deps.edn
@@ -7,17 +7,17 @@
                       org.clojure/google-closure-library-third-party]
          :mvn/version "1.11.60"}
         seancorfield/clj-new {:mvn/version "1.0.199"}
-        reagent/reagent {:mvn/version "0.9.1"}
-        re-frame/re-frame {:mvn/version "0.12.0"}{{#re-com?}}
+        reagent/reagent {:mvn/version "1.1.1"}
+        re-frame/re-frame {:mvn/version "1.2.0"}{{#re-com?}}
         re-com/re-com {:mvn/version "2.8.0"}{{/re-com?}}{{#re-pressed?}}
         re-pressed/re-pressed {:mvn/version "0.3.1"}{{/re-pressed?}}{{#breaking-point?}}
         breaking-point/breaking-point {:mvn/version "0.1.2"}{{/breaking-point?}}
         thheller/shadow-cljs {:mvn/version "2.20.14"}}
  :aliases
  {
-  :dev {:extra-deps {binaryage/devtools {:mvn/version "1.0.0"}{{#10x?}}
-                     day8.re-frame/re-frame-10x {:mvn/version "0.5.2"}
-                     day8.re-frame/tracing {:mvn/version "0.5.3"}{{/10x?}}{{#re-frisk?}}
+  :dev {:extra-deps {binaryage/devtools {:mvn/version "1.0.6"}{{#10x?}}
+                     day8.re-frame/re-frame-10x {:mvn/version "1.5.0"}
+                     day8.re-frame/tracing {:mvn/version "0.6.2"}{{/10x?}}{{#re-frisk?}}
                      re-frisk {:mvn/version "1.2.0"}{{/re-frisk?}}}
         :extra-paths ["src" "dev"]}
   :prod { {{#10x?}}:extra-deps {:day8.re-frame{tracing-stubs {:mvn/version "0.5.3"}}}{{/10x?}}

--- a/resources/clj/new/re_frame_template/deps.edn
+++ b/resources/clj/new/re_frame_template/deps.edn
@@ -20,7 +20,7 @@
                      day8.re-frame/tracing {:mvn/version "0.5.3"}{{/10x?}}{{#re-frisk?}}
                      re-frisk {:mvn/version "1.2.0"}{{/re-frisk?}}}
         :extra-paths ["src" "dev"]}
-  :prod { {{#10x?}}:extra-deps {:day8.re-frame{tracing-stubs {:mvn/version "0.5.3"}}{{/10x?}}}
+  :prod { {{#10x?}}:extra-deps {:day8.re-frame{tracing-stubs {:mvn/version "0.5.3"}}}{{/10x?}}
          :run {:jvm-opts ["-Xmx1G"]}}
   :runner
   {:extra-deps {:com.cognitect/test-runner

--- a/resources/clj/new/re_frame_template/deps.edn
+++ b/resources/clj/new/re_frame_template/deps.edn
@@ -16,7 +16,7 @@
  :aliases
  {
   :dev {:extra-deps {binaryage/devtools {:mvn/version "1.0.0"}{{#10x?}}
-                     day8.re-frame/re-frame-10x {:mvn/version "0.6.3"}
+                     day8.re-frame/re-frame-10x {:mvn/version "0.5.2"}
                      day8.re-frame/tracing {:mvn/version "0.5.3"}{{/10x?}}{{#re-frisk?}}
                      re-frisk {:mvn/version "1.2.0"}{{/re-frisk?}}}
         :extra-paths ["src" "dev"]}

--- a/resources/clj/new/re_frame_template/deps.edn
+++ b/resources/clj/new/re_frame_template/deps.edn
@@ -7,11 +7,11 @@
                       org.clojure/google-closure-library-third-party]
          :mvn/version "1.11.60"}
         seancorfield/clj-new {:mvn/version "1.0.199"}
-        reagent {:mvn/version "0.9.1"}
-        re-frame {:mvn/version "0.12.0"}{{#re-com?}}
-        re-com {:mvn/version "2.8.0"}{{/re-com?}}{{#re-pressed?}}
-        re-pressed {:mvn/version "0.3.1"}{{/re-pressed?}}{{#breaking-point?}}
-        breaking-point {:mvn/version "0.1.2"}{{/breaking-point?}}
+        reagent/reagent {:mvn/version "0.9.1"}
+        re-frame/re-frame {:mvn/version "0.12.0"}{{#re-com?}}
+        re-com/re-com {:mvn/version "2.8.0"}{{/re-com?}}{{#re-pressed?}}
+        re-pressed/re-pressed {:mvn/version "0.3.1"}{{/re-pressed?}}{{#breaking-point?}}
+        breaking-point/breaking-point {:mvn/version "0.1.2"}{{/breaking-point?}}
         thheller/shadow-cljs {:mvn/version "2.20.14"}}
  :aliases
  {

--- a/resources/clj/new/re_frame_template/package.json
+++ b/resources/clj/new/re_frame_template/package.json
@@ -5,5 +5,9 @@
         "karma-chrome-launcher": "3.1.0",
         "karma-cljs-test": "0.1.0",
         "karma-junit-reporter": "2.0.1"{{/test?}}
+  },
+    "dependencies": {
+        "react": "17.0.2",
+        "react-dom": "17.0.2"
   }
 }

--- a/resources/clj/new/re_frame_template/package.json
+++ b/resources/clj/new/re_frame_template/package.json
@@ -1,6 +1,6 @@
 {
     "devDependencies": {
-        "shadow-cljs": "2.8.96"{{#test?}},
+        "shadow-cljs": "2.20.14"{{#test?}},
         "karma": "5.0.2",
         "karma-chrome-launcher": "3.1.0",
         "karma-cljs-test": "0.1.0",

--- a/resources/clj/new/re_frame_template/src/core.cljs
+++ b/resources/clj/new/re_frame_template/src/core.cljs
@@ -1,6 +1,6 @@
 (ns {{namespace}}.core
     (:require
-     [reagent.core :as reagent]
+     [reagent.dom :as rdom]
      [re-frame.core :as re-frame]{{#re-pressed?}}
      [re-pressed.core :as rp]{{/re-pressed?}}{{#breaking-point?}}
      [breaking-point.core :as bp]{{/breaking-point?}}
@@ -17,7 +17,7 @@
 
 (defn ^:dev/after-load mount-root []
   (re-frame/clear-subscription-cache!)
-  (reagent/render [views/main-panel]
+  (rdom/render [views/main-panel]
                   (.getElementById js/document "app")))
 
 (defn init []{{#routes?}}


### PR DESCRIPTION
Fixes #2 

`shadow-cljs` does not work with JDK 15+ (see note [here](https://clojurians-log.clojureverse.org/shadow-cljs/2021-03-26/1616778977.187300)) and upgrading it required upgrading Clojure and a few other packages.

I went ahead and upgraded `reagent`, `re-frame`, and `re-frame-10x` as well.